### PR TITLE
uids with modularized code

### DIFF
--- a/pallets/subtensor/src/block_reward.rs
+++ b/pallets/subtensor/src/block_reward.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+impl<T: Trait> Module<T> {
+	/// Returns the bitcoin inflation rate at passed block number. We use a mapping between the bitcoin and substrate blocks.
+	/// Substrate blocks mint 100x faster and so the halving time and inflation rate need to be correspondingly changed.
+	/// Each block produces 0.5 x 10^12 tokens, or semantically, 0.5 full coins every 6 seconds. Likewise, the halving
+	/// occurs every 21 million blocks. Like bitcoin, this ensures there can only ever be 21 million full tokens 
+	/// created. In our case this ammount is furthre limited since inflation is only triggered by calling peers.
+	/// The inflation is therefore not continuous, and we lose out when peers fail to emit with their stake, or
+	/// fail to emit before a halving.
+	/// 
+	/// # Args:
+	///  	* `now` (&T::BlockNumber):
+	/// 		- The block number we wish to know the inflation rate at.
+	/// 
+	/// # Returns
+	/// 	* block_reward (U32F32):
+	/// 		- The number of tokens to emit at this block as a fixed point.
+	/// 	
+	pub fn block_reward(now: &<T as system::Trait>::BlockNumber) -> U32F32 {
+
+		// --- We convert the block number to u32 and then to a fixed point.
+		let elapsed_blocks_u32 = TryInto::try_into(*now).ok().expect("blockchain will not exceed 2^32 blocks; QED.");
+		let elapsed_blocks_u32_f32 = U32F32::from_num(elapsed_blocks_u32);
+
+		// --- We get the initial block reward.
+		// TODO(const): should be 0.5 x 10 ^ 12 not 0.5
+		// Bitcoin block reward started at 50 tokens per block and the average substrate block time is 6 seconds. 
+		// Therefore the equivalent halving is (50 blocks) / (10 min * 60 sec / 6 sec) = (50) / (100) = (0.5 tokens per block)
+		let block_reward = U32F32::from_num(0.5);
+
+		// --- We calculate the number of halvings since the chain was initialized
+		// Bitcoin inflation halves every 210,000 blocks which mint every 10 minutes.
+		// The average substrate block time is 6 seconds.
+		// The equivalent halving is (210,000 blocks) * (10 min * 60 sec / 6 sec) =  (210,000) * (100) = (21,000,000 blocks)
+		let block_halving = U32F32::from_num(21000000);
+		let fractional_halvings = elapsed_blocks_u32_f32 / block_halving;
+		let floored_halvings = fractional_halvings.floor().to_num::<u32>();
+		debug::info!("block_halving: {:?}", block_halving);
+		debug::info!("floored_halvings: {:?}", floored_halvings);
+
+		// --- We shift the block reward for each halving to get the actual reward at this block.
+		// NOTE: Underflow occurs in 21,000,000 * (16 + 4) blocks, essentially never.
+		let block_reward_shift = block_reward.overflowing_shr(floored_halvings).0;
+
+		// --- We return the result.
+		block_reward_shift
+	}
+}

--- a/pallets/subtensor/src/block_reward.rs
+++ b/pallets/subtensor/src/block_reward.rs
@@ -33,13 +33,13 @@ impl<T: Trait> Module<T> {
 		// The average substrate block time is 6 seconds.
 		// The equivalent halving is (210,000 blocks) * (10 min * 60 sec / 6 sec) =  (210,000) * (100) = (21,000,000 blocks)
 		let block_halving = U64F64::from_num(21000000);
-		let fractional_halvings = elapsed_blocks_u64_f64 / block_halving;
+        let fractional_halvings = elapsed_blocks_u64_f64 / block_halving;
 		debug::info!("block_halving: {:?}", block_halving);
 		debug::info!("fractional_halvings: {:?}", fractional_halvings);
 
 		// --- We shift the block reward for each halving to get the actual reward at this block.
-		// NOTE: Underflow occurs in 21,000,000 * 64 blocks, essentially never QED.
-		let block_reward_shift = block_reward / ( U64F64::from_num(2) ^ (fractional_halvings) );
+		// NOTE: Underflow occurs in 21,000,000 * 64 blocks, essentially never QED.        
+        let block_reward_shift = block_reward.overflowing_shr(fractional_halvings.to_num::<u32>()).0;
 
 		// --- We return the result.
 		block_reward_shift

--- a/pallets/subtensor/src/block_reward.rs
+++ b/pallets/subtensor/src/block_reward.rs
@@ -14,34 +14,32 @@ impl<T: Trait> Module<T> {
 	/// 		- The block number we wish to know the inflation rate at.
 	/// 
 	/// # Returns
-	/// 	* block_reward (U32F32):
+	/// 	* block_reward (U64F64):
 	/// 		- The number of tokens to emit at this block as a fixed point.
 	/// 	
-	pub fn block_reward(now: &<T as system::Trait>::BlockNumber) -> U32F32 {
+	pub fn block_reward(now: &<T as system::Trait>::BlockNumber) -> U64F64 {
 
-		// --- We convert the block number to u32 and then to a fixed point.
-		let elapsed_blocks_u32 = TryInto::try_into(*now).ok().expect("blockchain will not exceed 2^32 blocks; QED.");
-		let elapsed_blocks_u32_f32 = U32F32::from_num(elapsed_blocks_u32);
+		// --- We convert the block number to u64 and then to a fixed point.
+		let elapsed_blocks_u64 = TryInto::try_into(*now).ok().expect("blockchain will not exceed 2^64 blocks; QED.");
+		let elapsed_blocks_u64_f64 = U64F64::from_num(elapsed_blocks_u64);
 
 		// --- We get the initial block reward.
-		// TODO(const): should be 0.5 x 10 ^ 12 not 0.5
 		// Bitcoin block reward started at 50 tokens per block and the average substrate block time is 6 seconds. 
-		// Therefore the equivalent halving is (50 blocks) / (10 min * 60 sec / 6 sec) = (50) / (100) = (0.5 tokens per block)
-		let block_reward = U32F32::from_num(0.5);
+		// Therefore the equivalent halving is (50 blocks) / (10 min * 60 sec / 6 sec) = (50) / (100) = (0.5 tokens per block) or 0.5 * 10^9 = 500000000
+		let block_reward = U64F64::from_num(500000000);
 
 		// --- We calculate the number of halvings since the chain was initialized
 		// Bitcoin inflation halves every 210,000 blocks which mint every 10 minutes.
 		// The average substrate block time is 6 seconds.
 		// The equivalent halving is (210,000 blocks) * (10 min * 60 sec / 6 sec) =  (210,000) * (100) = (21,000,000 blocks)
-		let block_halving = U32F32::from_num(21000000);
-		let fractional_halvings = elapsed_blocks_u32_f32 / block_halving;
-		let floored_halvings = fractional_halvings.floor().to_num::<u32>();
+		let block_halving = U64F64::from_num(21000000);
+		let fractional_halvings = elapsed_blocks_u64_f64 / block_halving;
 		debug::info!("block_halving: {:?}", block_halving);
-		debug::info!("floored_halvings: {:?}", floored_halvings);
+		debug::info!("fractional_halvings: {:?}", fractional_halvings);
 
 		// --- We shift the block reward for each halving to get the actual reward at this block.
-		// NOTE: Underflow occurs in 21,000,000 * (16 + 4) blocks, essentially never.
-		let block_reward_shift = block_reward.overflowing_shr(floored_halvings).0;
+		// NOTE: Underflow occurs in 21,000,000 * 64 blocks, essentially never QED.
+		let block_reward_shift = block_reward / ( U64F64::from_num(2) ^ (fractional_halvings) );
 
 		// --- We return the result.
 		block_reward_shift

--- a/pallets/subtensor/src/emission.rs
+++ b/pallets/subtensor/src/emission.rs
@@ -1,26 +1,27 @@
 use super::*;
+use frame_support::debug::RuntimeLogger;
 
 impl<T: Trait> Module<T> {
-/// TODO(const & paralax): The self emission can be used to fund the transaction, this allows us to remove the need
+	/// TODO(const & paralax): The self emission can be used to fund the transaction, this allows us to remove the need
 	/// for transactions costs.
 	/// Emits inflation from the calling neuron to neighbors and themselves. Returns the total amount of emitted stake.
 	/// The inflation available to this caller is given by (blocks_since_last_emit) * (inflation_per_block) * (this_neurons_stake) / (total_stake).
 	/// Neurons are incentivized to make calls to this function often as-to maximize inflation in the graph.
-	///
+	/// 
 	/// # Args:
 	///  	* `caller` (&T::AccountId):
 	/// 		- The associated calling neuron key. Not a signature
-	/// 		just the associated public key. Checking the permissions is left to
+	/// 		just the associated public key. Checking the permissions is left to 
 	/// 		the calling function.
-	///
+	/// 
 	/// # Returns
 	/// 	* emission (u32):
 	/// 		- The total amount emitted to the caller.
-	///
-	pub fn emit( caller: &T::AccountId ) -> u32 {
+	/// 	
+	pub fn emit( caller_uid: u64 ) -> u32 {
 		// --- We init the Runtimelogger for WASM debugging
 		RuntimeLogger::init();
-		debug::info!("--- Calling emit, caller: {:?}", caller);
+		debug::info!("--- Calling emit, caller_uid: {:?}", caller_uid);
 
 		// --- We dont check that the caller exists in the Neuron set with corresponding
 		// mapped values. These are initialized on subscription. This should never
@@ -28,23 +29,23 @@ impl<T: Trait> Module<T> {
 		// ensure!(Neurons::<T>::contains_key(&caller), Error::<T>::NotActive);
 		// ensure!(Stake::<T>::contains_key(&caller), Error::<T>::NotActive);
 		// ensure!(LastEmit::<T>::contains_key(&caller), Error::<T>::NotActive);
-		// ensure!(WeightKeys::<T>::contains_key(&caller), Error::<T>::NotActive);
+		// ensure!(WeightUids::<T>::contains_key(&caller), Error::<T>::NotActive);
 		// ensure!(WeightVals::<T>::contains_key(&caller), Error::<T>::NotActive);
 
 		// --- We get the current block reward and the last time the user emitted.
-		// This is needed to determine the proportion of inflation allocated to
+		// This is needed to determine the proportion of inflation allocated to 
 		// the caller. Note also, that the block reward is a decreasing function
 		// callers want to call emit before the block inflation decreases.
-		let last_emit: T::BlockNumber = LastEmit::<T>::get(&caller);
+		let last_emit: T::BlockNumber = LastEmit::<T>::get( caller_uid );
 		let current_block = system::Module::<T>::block_number();
 		let block_reward = Self::block_reward(&current_block);
 		debug::info!("Last emit block: {:?}", last_emit);
 		debug::info!("Current block: {:?}", current_block);
 		debug::info!("Block reward: {:?}", block_reward);
 
-		// --- We get the number of blocks since the last emit and
-		// convert types into U32F32. The floating precision enables
-		// the following calculations.
+		// --- We get the number of blocks since the last emit and 
+		// convert types into U32F32. The floating precision enables 
+		// the following calculations. 
 		let elapsed_blocks = current_block - last_emit;
 		let elapsed_blocks_u32: usize = TryInto::try_into(elapsed_blocks).ok().expect("blockchain will not exceed 2^32 blocks; qed");
 		let elapsed_blocks_u32_f32 = U32F32::from_num(elapsed_blocks_u32);
@@ -59,17 +60,17 @@ impl<T: Trait> Module<T> {
 		// converting them to U32F32 for the following calculations.
 		let total_stake: u32  = TotalStake::get();
 		let total_stake_u32_f32 = U32F32::from_num(total_stake);
-		let caller_stake: u32 = Stake::<T>::get(&caller);
+		let caller_stake: u32 = Stake::get( caller_uid );
 		let caller_stake_u32_f32 = U32F32::from_num(caller_stake);
 		debug::info!("total_stake_u32_f32 {:?}", total_stake_u32_f32);
 		debug::info!("caller_stake_u32_f32 {:?}", caller_stake_u32_f32);
 		if total_stake_u32_f32 == U32F32::from_num(0) {
 			// total stake is zero, nothing to emit. Return without error.
-			return 0;
+			return 0;	
 		}
 
 		// --- We get the fraction of total stake held by the caller.
-		// This should only be zero if the caller has zero stake. Otherwise
+		// This should only be zero if the caller has zero stake. Otherwise 
 		// it returns a floating point (a.k.a, bits in the F32 part.)
 		let stake_fraction_u32_f32 = caller_stake_u32_f32 / total_stake_u32_f32;
 		debug::info!("stake_fraction_u32_f32 {:?}", stake_fraction_u32_f32);
@@ -90,27 +91,27 @@ impl<T: Trait> Module<T> {
 
 		// --- We get the callers weights. The total emission will be distributed
 		// according to these weights. Previous checks in fn set_weights ensure
-		// that the weight_vals sum to u32::max / are nomalized to 1.
-		let weight_vals: Vec<u32> = WeightVals::<T>::get( &caller );
-		let weight_keys: Vec<T::AccountId> = WeightKeys::<T>::get( &caller );
-		if weight_keys.is_empty() || weight_vals.is_empty() {
+		// that the weight_vals sum to u32::max / are nomalized to 1. 
+		let weight_vals: Vec<u32> = WeightVals::get( caller_uid );
+		let weight_uids: Vec<u64> = WeightUids::get( caller_uid );
+		if weight_uids.is_empty() || weight_vals.is_empty() {
 			// callers has no weights, nothing to emit. Return without error.
 			return 0;
 		}
 
-		// --- We iterate through the weights and distribute the caller's emission to
-		// neurons on a weighted basis. The emission is added as new stake to their
-		// staking account and the total emission is increased.
+		// --- We iterate through the weights and distribute the caller's emission to 
+		// neurons on a weighted basis. The emission is added as new stake to their 
+		// staking account and the total emission is increased. 
 		let mut total_new_stake_u32: u32 = 0; // Total stake added across all emissions.
-		for (i, dest_key) in weight_keys.iter().enumerate() {
+		for (i, dest_uid) in weight_uids.iter().enumerate() {
 
 			// --- We get the weight from neuron i to neuron j.
-			// The weights are normalized and sum to u32::max.
-			// This weight value as floating point value in the
+			// The weights are normalized and sum to u32::max. 
+			// This weight value as floating point value in the 
 			// range [0, 1] is thus given by w_ij_u32 / u32::max
 			let wij_u32_f32 = U32F32::from_num( weight_vals[i] );
 			let wij_norm_u32_f32 = wij_u32_f32 / U32F32::from_num( u32::MAX );
-			debug::info!("Emitting to {:?}", dest_key);
+			debug::info!("Emitting to {:?}", dest_uid);
 			debug::info!("wij {:?}", wij_norm_u32_f32);
 
 			// --- We get the emission from neuron i to neuron j.
@@ -120,35 +121,34 @@ impl<T: Trait> Module<T> {
 			debug::info!("emission_u32_f32 {:?}", emission_u32_f32);
 
 			// --- We increase the staking account by this new emission
-			// value by first converting both to u32f32 floats. The floating
+			// value by first converting both to u32f32 floats. The floating 
 			// point emission is dropped in the conversion back to u32.
-			let prev_stake: u32 = Stake::<T>::get(&dest_key);
-			let prev_stake_u32_f32 = U32F32::from_num(prev_stake);
+			let prev_stake: u32 = Stake::get( dest_uid );
+			let prev_stake_u32_f32 = U32F32::from_num( prev_stake );
 			let new_stake_u32_f32 = prev_stake_u32_f32 + emission_u32_f32;
 			let new_stake_u32: u32 = new_stake_u32_f32.to_num::<u32>();
-			Stake::<T>::insert(&dest_key, new_stake_u32);
+			Stake::insert(dest_uid, new_stake_u32);
 			debug::info!("prev_stake_u32_f32 {:?}", prev_stake_u32_f32);
 			debug::info!("new_stake_u32_f32 {:?} = {:?} + {:?}", new_stake_u32_f32, prev_stake_u32_f32, emission_u32_f32);
 			debug::info!("new_stake_u32 {:?}", new_stake_u32);
 
-			// --- We increase the total stake emitted. For later addition to
+			// --- We increase the total stake emitted. For later addition to 
 			// the total staking pool.
 			total_new_stake_u32 = total_new_stake_u32 + new_stake_u32
 		}
-
+		
 		// --- We add the total amount of stake emitted to the staking pool.
 		// Note: This value may not perfectly match total_emission_u32_f32 after rounding.
 		let total_stake: u32  = TotalStake::get();
-		TotalStake::put(total_stake + total_new_stake_u32);
+		TotalStake::put(total_stake + total_new_stake_u32); 
 		debug::info!("Adding new total stake {:?}, now {:?}", total_stake, TotalStake::get());
 
 		// --- Finally, we update the last emission by the caller.
-		LastEmit::<T>::insert(&caller, current_block);
+		LastEmit::<T>::insert( caller_uid, current_block );
 		debug::info!("The old last emit: {:?} the new last emit: {:?}", last_emit, current_block);
-
+	
 		// --- Return ok.
 		debug::info!("--- Done emit");
 		return total_new_stake_u32;
 	}
-
 }

--- a/pallets/subtensor/src/emission.rs
+++ b/pallets/subtensor/src/emission.rs
@@ -2,41 +2,61 @@ use super::*;
 use frame_support::debug::RuntimeLogger;
 
 impl<T: Trait> Module<T> {
-	/// TODO(const & paralax): The self emission can be used to fund the transaction, this allows us to remove the need
-	/// for transactions costs.
+
+
 	/// Emits inflation from the calling neuron to neighbors and themselves. Returns the total amount of emitted stake.
 	/// The inflation available to this caller is given by (blocks_since_last_emit) * (inflation_per_block) * (this_neurons_stake) / (total_stake).
 	/// Neurons are incentivized to make calls to this function often as-to maximize inflation in the graph.
 	/// 
 	/// # Args:
-	///  	* `caller` (&T::AccountId):
-	/// 		- The associated calling neuron key. Not a signature
-	/// 		just the associated public key. Checking the permissions is left to 
-	/// 		the calling function.
+	///  	* `origin` (T::Origin):
+	/// 		- The transaction caller.
 	/// 
 	/// # Returns
-	/// 	* emission (u32):
+	/// 	* emission (u64):
 	/// 		- The total amount emitted to the caller.
 	/// 	
-	pub fn emit( caller_uid: u64 ) -> u32 {
+	pub fn do_emit( origin: T::Origin ) -> dispatch::DispatchResult {
+		// ---- We check the transaction is signed by the caller
+        // and retrieve the T::AccountId pubkey information.
+        let caller = ensure_signed(origin)?;
+        debug::info!("--- Called emit with caller {:?}", caller);
+
+        // ---- We query the Neuron set for the neuron data stored under
+        // the passed hotkey and retrieve it as a NeuronMetadata struct.
+        ensure!(Neurons::<T>::contains_key(&caller), Error::<T>::NotActive);
+        let neuron: NeuronMetadataOf<T> = Neurons::<T>::get(&caller);
+		debug::info!("Got metadata for hotkey {:?}", caller);
+
+		// ---- We call emit for this neuron.
+		Self::emit_from_uid( neuron.uid );
+
+		// ---- Done.
+		Ok(())		
+	}
+
+	/// Emits inflation from the neuron uid to neighbors and themselves. Returns the total amount of emitted stake.
+	/// The inflation available to this caller is given by (blocks_since_last_emit) * (inflation_per_block) * (this_neurons_stake) / (total_stake).
+	/// Neurons are incentivized to make calls to this function often as-to maximize inflation in the graph.
+	/// 
+	/// # Args:
+	///  	* `neuron_uid` (u64):
+	/// 		- The uid for the neuron we are emitting from. 
+	/// 
+	/// # Returns
+	/// 	* emission (u64):
+	/// 		- The total amount emitted to the caller.
+	/// 	
+	pub fn emit_from_uid( neuron_uid: u64 ) -> u64 {
 		// --- We init the Runtimelogger for WASM debugging
 		RuntimeLogger::init();
-		debug::info!("--- Calling emit, caller_uid: {:?}", caller_uid);
-
-		// --- We dont check that the caller exists in the Neuron set with corresponding
-		// mapped values. These are initialized on subscription. This should never
-		// occur unless the calling function does not check the callers subscription first.
-		// ensure!(Neurons::<T>::contains_key(&caller), Error::<T>::NotActive);
-		// ensure!(Stake::<T>::contains_key(&caller), Error::<T>::NotActive);
-		// ensure!(LastEmit::<T>::contains_key(&caller), Error::<T>::NotActive);
-		// ensure!(WeightUids::<T>::contains_key(&caller), Error::<T>::NotActive);
-		// ensure!(WeightVals::<T>::contains_key(&caller), Error::<T>::NotActive);
-
+		debug::info!("--- Calling emit, neuron_uid: {:?}", neuron_uid);
+		
 		// --- We get the current block reward and the last time the user emitted.
 		// This is needed to determine the proportion of inflation allocated to 
 		// the caller. Note also, that the block reward is a decreasing function
 		// callers want to call emit before the block inflation decreases.
-		let last_emit: T::BlockNumber = LastEmit::<T>::get( caller_uid );
+		let last_emit: T::BlockNumber = LastEmit::<T>::get( neuron_uid );
 		let current_block = system::Module::<T>::block_number();
 		let block_reward = Self::block_reward(&current_block);
 		debug::info!("Last emit block: {:?}", last_emit);
@@ -44,37 +64,37 @@ impl<T: Trait> Module<T> {
 		debug::info!("Block reward: {:?}", block_reward);
 
 		// --- We get the number of blocks since the last emit and 
-		// convert types into U32F32. The floating precision enables 
+		// convert types into U64F64. The floating precision enables 
 		// the following calculations. 
 		let elapsed_blocks = current_block - last_emit;
-		let elapsed_blocks_u32: usize = TryInto::try_into(elapsed_blocks).ok().expect("blockchain will not exceed 2^32 blocks; qed");
-		let elapsed_blocks_u32_f32 = U32F32::from_num(elapsed_blocks_u32);
-		debug::info!("elapsed_blocks_u32: {:?}", elapsed_blocks_u32);
-		debug::info!("elapsed_blocks_u32_f32: {:?}", elapsed_blocks_u32_f32);
-		if elapsed_blocks_u32_f32 == U32F32::from_num(0) {
+		let elapsed_blocks_u64: usize = TryInto::try_into(elapsed_blocks).ok().expect("blockchain will not exceed 2^64 blocks; qed");
+		let elapsed_blocks_u64_f64 = U64F64::from_num(elapsed_blocks_u64);
+		debug::info!("elapsed_blocks_u64: {:?}", elapsed_blocks_u64);
+		debug::info!("elapsed_blocks_u64_f64: {:?}", elapsed_blocks_u64_f64);
+		if elapsed_blocks_u64_f64 == U64F64::from_num(0) {
 			// No blocks have passed, nothing to emit. Return without error.
 			return 0;
 		}
 
 		// --- We get the callers stake and the total stake ammounts
-		// converting them to U32F32 for the following calculations.
-		let total_stake: u32  = TotalStake::get();
-		let total_stake_u32_f32 = U32F32::from_num(total_stake);
-		let caller_stake: u32 = Stake::get( caller_uid );
-		let caller_stake_u32_f32 = U32F32::from_num(caller_stake);
-		debug::info!("total_stake_u32_f32 {:?}", total_stake_u32_f32);
-		debug::info!("caller_stake_u32_f32 {:?}", caller_stake_u32_f32);
-		if total_stake_u32_f32 == U32F32::from_num(0) {
+		// converting them to U64F64 for the following calculations.
+		let total_stake: u64  = TotalStake::get();
+		let total_stake_u64_f64 = U64F64::from_num(total_stake);
+		let caller_stake: u64 = Stake::get( neuron_uid );
+		let caller_stake_u64_f64 = U64F64::from_num(caller_stake);
+		debug::info!("total_stake_u64_f64 {:?}", total_stake_u64_f64);
+		debug::info!("caller_stake_u64_f64 {:?}", caller_stake_u64_f64);
+		if total_stake_u64_f64 == U64F64::from_num(0) {
 			// total stake is zero, nothing to emit. Return without error.
 			return 0;	
 		}
 
 		// --- We get the fraction of total stake held by the caller.
 		// This should only be zero if the caller has zero stake. Otherwise 
-		// it returns a floating point (a.k.a, bits in the F32 part.)
-		let stake_fraction_u32_f32 = caller_stake_u32_f32 / total_stake_u32_f32;
-		debug::info!("stake_fraction_u32_f32 {:?}", stake_fraction_u32_f32);
-		if stake_fraction_u32_f32 == U32F32::from_num(0) {
+		// it returns a floating point (a.k.a, bits in the F64 part.)
+		let stake_fraction_u64_f64 = caller_stake_u64_f64 / total_stake_u64_f64;
+		debug::info!("stake_fraction_u64_f64 {:?}", stake_fraction_u64_f64);
+		if stake_fraction_u64_f64 == U64F64::from_num(0) {
 			// stake fraction is zero, nothing to emit. Return without error.
 			return 0;
 		}
@@ -82,18 +102,18 @@ impl<T: Trait> Module<T> {
 		// --- We calculate the total emission available to the caller.
 		// the block reward is positive and non-zero, so is the stake_fraction and elapsed blocks.
 		// this ensures the total_emission is positive non-zero. To begin the block reward is (0.5 * 10^12).
-		let callers_emission_u32_f32 = stake_fraction_u32_f32 * block_reward * elapsed_blocks_u32_f32;
-		debug::info!("callers_emission_u32_f32: {:?} = {:?} * {:?} * {:?}", callers_emission_u32_f32, stake_fraction_u32_f32, block_reward, elapsed_blocks_u32_f32);
-		if callers_emission_u32_f32 == U32F32::from_num(0) {
+		let callers_emission_u64_f64 = stake_fraction_u64_f64 * block_reward * elapsed_blocks_u64_f64;
+		debug::info!("callers_emission_u64_f64: {:?} = {:?} * {:?} * {:?}", callers_emission_u64_f64, stake_fraction_u64_f64, block_reward, elapsed_blocks_u64_f64);
+		if callers_emission_u64_f64 == U64F64::from_num(0) {
 			// callers emission is zero, nothing to emit. Return without error.
 			return 0;
 		}
 
 		// --- We get the callers weights. The total emission will be distributed
 		// according to these weights. Previous checks in fn set_weights ensure
-		// that the weight_vals sum to u32::max / are nomalized to 1. 
-		let weight_vals: Vec<u32> = WeightVals::get( caller_uid );
-		let weight_uids: Vec<u64> = WeightUids::get( caller_uid );
+		// that the weight_vals sum to u64::max / are nomalized to 1. 
+		let weight_vals: Vec<u32> = WeightVals::get( neuron_uid );
+		let weight_uids: Vec<u64> = WeightUids::get( neuron_uid );
 		if weight_uids.is_empty() || weight_vals.is_empty() {
 			// callers has no weights, nothing to emit. Return without error.
 			return 0;
@@ -102,53 +122,53 @@ impl<T: Trait> Module<T> {
 		// --- We iterate through the weights and distribute the caller's emission to 
 		// neurons on a weighted basis. The emission is added as new stake to their 
 		// staking account and the total emission is increased. 
-		let mut total_new_stake_u32: u32 = 0; // Total stake added across all emissions.
+		let mut total_new_stake_u64: u64 = 0; // Total stake added across all emissions.
 		for (i, dest_uid) in weight_uids.iter().enumerate() {
 
 			// --- We get the weight from neuron i to neuron j.
-			// The weights are normalized and sum to u32::max. 
+			// The weights are normalized and sum to u64::max. 
 			// This weight value as floating point value in the 
-			// range [0, 1] is thus given by w_ij_u32 / u32::max
-			let wij_u32_f32 = U32F32::from_num( weight_vals[i] );
-			let wij_norm_u32_f32 = wij_u32_f32 / U32F32::from_num( u32::MAX );
+			// range [0, 1] is thus given by w_ij_u64 / u64::max
+			let wij_u64_f64 = U64F64::from_num( weight_vals[i] );
+			let wij_norm_u64_f64 = wij_u64_f64 / U64F64::from_num( u64::MAX );
 			debug::info!("Emitting to {:?}", dest_uid);
-			debug::info!("wij {:?}", wij_norm_u32_f32);
+			debug::info!("wij {:?}", wij_norm_u64_f64);
 
 			// --- We get the emission from neuron i to neuron j.
 			// The multiplication of the weight \in [0, 1]
 			// by the total_emission gives us the emission proportion.
-			let emission_u32_f32 = callers_emission_u32_f32 * wij_norm_u32_f32;
-			debug::info!("emission_u32_f32 {:?}", emission_u32_f32);
+			let emission_u64_f64 = callers_emission_u64_f64 * wij_norm_u64_f64;
+			debug::info!("emission_u64_f64 {:?}", emission_u64_f64);
 
 			// --- We increase the staking account by this new emission
-			// value by first converting both to u32f32 floats. The floating 
-			// point emission is dropped in the conversion back to u32.
-			let prev_stake: u32 = Stake::get( dest_uid );
-			let prev_stake_u32_f32 = U32F32::from_num( prev_stake );
-			let new_stake_u32_f32 = prev_stake_u32_f32 + emission_u32_f32;
-			let new_stake_u32: u32 = new_stake_u32_f32.to_num::<u32>();
-			Stake::insert(dest_uid, new_stake_u32);
-			debug::info!("prev_stake_u32_f32 {:?}", prev_stake_u32_f32);
-			debug::info!("new_stake_u32_f32 {:?} = {:?} + {:?}", new_stake_u32_f32, prev_stake_u32_f32, emission_u32_f32);
-			debug::info!("new_stake_u32 {:?}", new_stake_u32);
+			// value by first converting both to U64F64 floats. The floating 
+			// point emission is dropped in the conversion back to u64.
+			let prev_stake: u64 = Stake::get( dest_uid );
+			let prev_stake_u64_f64 = U64F64::from_num( prev_stake );
+			let new_stake_u64_f64 = prev_stake_u64_f64 + emission_u64_f64;
+			let new_stake_u64: u64 = new_stake_u64_f64.to_num::<u64>();
+			Stake::insert(dest_uid, new_stake_u64);
+			debug::info!("prev_stake_u64_f64 {:?}", prev_stake_u64_f64);
+			debug::info!("new_stake_u64_f64 {:?} = {:?} + {:?}", new_stake_u64_f64, prev_stake_u64_f64, emission_u64_f64);
+			debug::info!("new_stake_u64 {:?}", new_stake_u64);
 
 			// --- We increase the total stake emitted. For later addition to 
 			// the total staking pool.
-			total_new_stake_u32 = total_new_stake_u32 + new_stake_u32
+			total_new_stake_u64 = total_new_stake_u64 + emission_u64_f64.to_num::<u64>();
 		}
 		
 		// --- We add the total amount of stake emitted to the staking pool.
-		// Note: This value may not perfectly match total_emission_u32_f32 after rounding.
-		let total_stake: u32  = TotalStake::get();
-		TotalStake::put(total_stake + total_new_stake_u32); 
-		debug::info!("Adding new total stake {:?}, now {:?}", total_stake, TotalStake::get());
+		// Note: This value may not perfectly match total_emission_u64_f64 after rounding.
+		let total_stake: u64  = TotalStake::get();
+		TotalStake::put(total_stake + total_new_stake_u64); 
+		debug::info!("Adding new total stake {:?} to old total {:?} now {:?}", total_new_stake_u64, total_stake, TotalStake::get());
 
 		// --- Finally, we update the last emission by the caller.
-		LastEmit::<T>::insert( caller_uid, current_block );
+		LastEmit::<T>::insert( neuron_uid, current_block );
 		debug::info!("The old last emit: {:?} the new last emit: {:?}", last_emit, current_block);
 	
 		// --- Return ok.
 		debug::info!("--- Done emit");
-		return total_new_stake_u32;
+		return total_new_stake_u64;
 	}
 }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1,6 +1,3 @@
-// On spliting modules : https://stackoverflow.com/questions/56902167/in-substrate-is-there-a-way-to-use-storage-and-functions-from-one-custom-module
-
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // --- Frame imports.
@@ -18,9 +15,7 @@ mod weights;
 mod staking;
 mod subscribing;
 mod emission;
-
-use frame_support::debug::RuntimeLogger;
-
+mod block_reward;
 
 /// --- Configure the pallet by specifying the parameters and types on which it depends.
 pub trait Trait: frame_system::Trait {
@@ -32,7 +27,6 @@ pub trait Trait: frame_system::Trait {
 }
 
 // ---- Create account types for the NeuronMetadata struct.
-// Account is of type system::Trait::AccoountId.
 type AccountIdOf<T> = <T as system::Trait>::AccountId;
 type NeuronMetadataOf<T> = NeuronMetadata<AccountIdOf<T>>;
 
@@ -47,6 +41,12 @@ pub struct NeuronMetadata <AccountId> {
 	/// ---- The endpoint's ip type, 4 for ipv4 and 6 for ipv6. 
 	ip_type: u8,
 
+	/// ---- The endpoint's unique identifier. The chain can have
+	/// 18,446,744,073,709,551,615 neurons before we overflow. However
+	/// by this point the chain would be 10 terabytes just from metadata
+	/// alone.
+	uid: u64, 
+
 	/// ---- The associated coldkey account. 
 	/// Staking and unstaking transactions must be made by this account.
 	/// The hotkey account (in the Neurons map) has permission to call emit
@@ -57,32 +57,38 @@ pub struct NeuronMetadata <AccountId> {
 // The pallet's runtime storage items.
 decl_storage! {
 	trait Store for Module<T: Trait> as SubtensorModule {
-	
-		/// ---- Maps between a neuron's hotkey account address and that neurons
-		/// weights, a.k.a is row_weights in the square matrix W. The vector of keys
-		/// and the vector of weights must be the same length and if they exist
-		/// their values must be positive and sum to the largest u32 value.
-		pub WeightKeys: map hasher(blake2_128_concat) T::AccountId => Vec<T::AccountId>;
-		pub WeightVals: map hasher(blake2_128_concat) T::AccountId => Vec<u32>;
 
-		/// ---- Maps between a neuron's hotkey account address and the block number
+		/// ----  Maps between a neuron's hotkey account address and additional 
+		/// metadata associated with that neuron. All other maps, map between the with a uid. 
+		/// The metadata contains that uid, the ip, port, and coldkey address.
+		pub Neurons get(fn neuron): map hasher(blake2_128_concat) T::AccountId => NeuronMetadataOf<T>;
+	
+		/// ---- List of values which map between a neuron's uid that neurons
+		/// weights, a.k.a is row_weights in the square matrix W. Each outward edge
+		/// is represented by a (u64, u32) tuple determining the endpoint and weight
+		/// value respectively. Each giga byte of chain storage can hold history for
+		/// 83 million weights. 
+		pub WeightUids: map hasher(twox_64_concat) u64 => Vec<u64>;
+		pub WeightVals: map hasher(twox_64_concat) u64 => Vec<u32>;
+
+		/// ---- Maps between a neuron's hotkey uid and the block number
 		/// when that peer last called an emission. The last emit time is used to determin
 		/// the proportion of inflation remaining to emit during the next emit call.
-		pub LastEmit get(fn block): map hasher(blake2_128_concat) T::AccountId => T::BlockNumber;
+		pub LastEmit get(fn last_emit): map hasher(twox_64_concat) u64 => T::BlockNumber;
 		
-		/// ----  Maps between a neuron's hotkey account address and additional 
-		/// metadata associated with that neuron. Specifically, the ip,port, and coldkey address.
-		pub Neurons get(fn neuron): map hasher(blake2_128_concat) T::AccountId => NeuronMetadataOf<T>;
-
-		/// ----  Maps between a neuron's hotkey account address and the number of
+		/// ----  Maps between a neuron's hotkey uid and the number of
 		/// staked tokens under that key.
-		pub Stake get(fn stake): map hasher(blake2_128_concat) T::AccountId => u32;
+		pub Stake get(fn stake): map hasher(twox_64_concat) u64 => u32;
 
 		/// ---- Stores the amount of currently staked token.
 		TotalStake: u32;
 
 		/// ---- Stores the number of active neurons.
-		NeuronCount: u32;
+		ActiveCount: u32;
+
+		/// ---- The next uid allocated to a subscribing neuron. Or a count of how many peers
+		/// have ever subscribed.
+		NextUID: u64;
 	}
 }
 
@@ -172,30 +178,51 @@ decl_module! {
 		// Events must be initialized if they are used by the pallet.
 		fn deposit_event() = default;
 
-
-		/// --- Sets weights to public keys on the neuron
-		/// The dests parameter is a vector of public keys
-		/// The values parameter is a vector of unsigned 32 bit integers
-		/// These 32 bit integers should represent a decimal number where when all bits
-		/// are set, this represents 1.0.
-		///
-		/// The function normalizes all integers to u32_max. This means that if the sum of all
+		/// --- Sets the caller weights for the incentive mechanism. The call can be
+		/// made from the hotkey account so is potentially insecure, however, the damage 
+		/// of changing weights is minimal if caught early. This function includes all the
+		/// checks that the passed weights meet the requirements. Stored as u32s they represent
+		/// rational values in the range [0,1] which sum to 1 and can be interpreted as
+		/// probabilities. The specific weights determine how inflation propagates outward 
+		/// from this peer. Because this function changes the inflation distribution it 
+		/// triggers an emit before values are changed on the chain.
+		/// 
+		/// Note: The 32 bit integers weights should represent 1.0 as the max u32.
+		/// However, the function normalizes all integers to u32_max anyway. This means that if the sum of all
 		/// elements is larger or smaller than the amount of elements * u32_max, all elements
-		/// will be corrected for this deviation. See the unit tests on the bottom of this file
-		/// for more information.
-		///
-		/// After normalizing the weights, they are pushed on the chain and an event is issued.
+		/// will be corrected for this deviation. 
+		/// 
+		/// # Args:
+		/// 	* `origin`: (<T as frame_system::Trait>Origin):
+		/// 		- The caller, a hotkey who wishes to set their weights.
+		/// 
+		/// 	* `uids` (Vec<u64>):
+		/// 		- The edge endpoint for the weight, i.e. j for w_ij.
+		/// 
+		/// 	* `weights` (Vec<u32>):
+		/// 		- The u32 integer encoded weights. Interpreted as rational 
+		/// 		values in the range [0,1]. They must sum to in32::MAX.
+		/// 
+		/// # Emits:
+		/// 	`WeightsSet`:
+		/// 		- On successfully setting the weights on chain.
+		/// 
+		/// # Raises:
+		/// 	* `WeightVecNotEqualSize`:
+		/// 		- If the passed weights and uids have unequal size.
+		/// 
+		/// 	* `WeightSumToLarge`:
+		/// 		- When the calling coldkey is not associated with the hotkey account.
+		/// 
+		/// 	* `InsufficientBalance`:
+		/// 		- When the amount to stake exceeds the amount of balance in the
+		/// 		associated colkey account.
+		/// 	
 		#[weight = (0, DispatchClass::Operational, Pays::No)]
-		pub fn set_weights(origin,
-				dests: Vec<T::AccountId>,
-				values: Vec<u32>) -> dispatch::DispatchResult {
+		pub fn set_weights(origin, dests: Vec<u64>, weights: Vec<u32>) -> dispatch::DispatchResult {
 
-
-			Self::do_set_weights(origin, dests, values)
+			Self::do_set_weights(origin, dests, weights)
 		}
-
-
-
 
 		/// --- Adds stake to a neuron account. The call is made from the
 		/// coldkey account linked in the neurons's NeuronMetadata.
@@ -324,67 +351,9 @@ decl_module! {
 
 impl<T: Trait> Module<T> {
 
-	/// Returns the bitcoin inflation rate at block number. We use a mapping between the bitcoin blocks and substrate.
-	/// Substrate blocks mint 100x faster and so the halving time and emission rate need to correspondingly changed.
-	/// Each block produces 0.5 x 10^12 tokens, or semantically, as 0.5 full coins every 6 seconds. The halving
-	/// is occurs every 21 million blocks. Like bitcoin, this ensures there are only every 21 million full tokens
-	/// created. In our case this ammount is furthre limited since inflation is only triggered by calling peers.
-	/// The inflation is therefore not continuous, and we lose out when peers fail to emit with their stake, or
-	/// fail to emit before a halving.
-	///
-	/// # Args:
-	///  	* `now` (&T::BlockNumber):
-	/// 		- The block number we wish to return the block reward at (tau)
-	///
-	/// # Returns
-	/// 	* block_reward (U32F32):
-	/// 		- The number of tokens to emit at this block as a fixed point.
-	///
-	fn block_reward(now: &<T as system::Trait>::BlockNumber) -> U32F32 {
-
-		// --- We convert the block number to u32 and then to a fixed point for further
-		// calculations.
-		let elapsed_blocks_u32 = TryInto::try_into(*now).ok().expect("blockchain will not exceed 2^32 blocks; QED.");
-		let elapsed_blocks_u32_f32 = U32F32::from_num(elapsed_blocks_u32);
-
-		// --- We get the initial block reward.
-		// TODO(const): shoudl be 0.5 x 10 ^ 12.
-		// Bitcoin block reward started at 50 tokens per block.
-		// The average substrate block time is 6 seconds.
-		// The equivalent halving is (50 blocks) / (10 min * 60 sec / 6 sec) =  (50) / (100) = (0.5 tokens per block)
-		let block_reward = U32F32::from_num(0.5);
-
-		// --- We calculate the number of halvings since the chain was initialized
-		// Bitcoin block halving rate was 210,000 blocks at block every 10 minutes.
-		// The average substrate block time is 6 seconds.
-		// The equivalent halving is (210,000 blocks) * (10 min * 60 sec / 6 sec) =  (210,000) * (100) = (21,000,000 blocks)
-		let block_halving = U32F32::from_num(21000000);
-		let fractional_halvings = elapsed_blocks_u32_f32 / block_halving;
-		let floored_halvings = fractional_halvings.floor().to_num::<u32>();
-		debug::info!("block_halving: {:?}", block_halving);
-		debug::info!("floored_halvings: {:?}", floored_halvings);
-
-		// --- We shit the block reward for each halving to get the actual reward at this block.
-		// NOTE: Underflow occurs in 21,000,000 * (16 + 4) blocks essentially never.
-		let block_reward_shift = block_reward.overflowing_shr(floored_halvings).0;
-
-		// --- We return the result.
-		block_reward_shift
-	}
-
 	pub fn u32_to_balance(input: u32) -> <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance
 	{
 		input.into()
 	}
 
-
-
-
-
-
 }
-
-
-
-
-

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -378,9 +378,4 @@ impl<T: Trait> Module<T> {
 	{
 		input.try_into().ok()
 	}
-<<<<<<< HEAD
 }
-=======
-
-}
->>>>>>> eb8312e8e26b2b84349df07f08658289e4d57ad3

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -63,7 +63,7 @@ decl_storage! {
 		/// The metadata contains that uid, the ip, port, and coldkey address.
 		pub Neurons get(fn neuron): map hasher(blake2_128_concat) T::AccountId => NeuronMetadataOf<T>;
 	
-		/// ---- List of values which map between a neuron's uid that neurons
+		/// ---- List of values which map between a neuron's uid an that neuron's
 		/// weights, a.k.a is row_weights in the square matrix W. Each outward edge
 		/// is represented by a (u64, u32) tuple determining the endpoint and weight
 		/// value respectively. Each giga byte of chain storage can hold history for

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl<T: Trait> Module<T> {
-    pub fn do_add_stake(origin: T::Origin, hotkey: T::AccountId, ammount_staked: u32) -> dispatch::DispatchResult
+    pub fn do_add_stake(origin: T::Origin, hotkey: T::AccountId, ammount_staked: u64) -> dispatch::DispatchResult
     {
         // ---- We check the transaction is signed by the caller
         // and retrieve the T::AccountId pubkey information.
@@ -22,14 +22,18 @@ impl<T: Trait> Module<T> {
         // their stake or else can cheat the system by adding stake just before
         // and emission to maximize their inflation.
         // TODO(const): can we pay for this transaction through inflation.
-        Self::emit( neuron.uid );
+        Self::emit_from_uid( neuron.uid );
 
         // ---- We check that the calling coldkey contains enough funds to
         // create the staking transaction.
-        let staked_currency = Self::u32_to_balance( ammount_staked );
+        let staked_currency = Self::u64_to_balance( ammount_staked );
+        ensure!(staked_currency.is_some(), Error::<T>::CouldNotConvertToBalance);
+
+        let staked_currency = staked_currency.unwrap();
         let new_potential_balance = T::Currency::free_balance(&caller) - staked_currency;
         let can_withdraw = T::Currency::ensure_can_withdraw(&caller, staked_currency, WithdrawReasons::except(WithdrawReason::Tip), new_potential_balance).is_ok();
 
+       
         // ---- If we can withdraw the requested funds, we withdraw from the  
         // coldkey account and deposit the funds into the staking account of 
         // the associated hotkey-neuron.
@@ -41,12 +45,12 @@ impl<T: Trait> Module<T> {
             debug::info!("Withdrew {:?} from coldkey: {:?}", staked_currency, caller);
 
             // --- We update the hotkey's staking account with the new funds.
-            let hotkey_stake: u32 = Stake::get( neuron.uid );
+            let hotkey_stake: u64 = Stake::get( neuron.uid );
             Stake::insert( neuron.uid, hotkey_stake + ammount_staked);
             debug::info!("Added new stake: {:?} to hotkey {:?}", ammount_staked, hotkey);
 
             // --- We update the total staking pool with the new funds.
-            let total_stake: u32 = TotalStake::get();
+            let total_stake: u64 = TotalStake::get();
             TotalStake::put(total_stake + ammount_staked);
             debug::info!("Added {:?} to total stake, now {:?}", ammount_staked, TotalStake::get());
 
@@ -64,7 +68,7 @@ impl<T: Trait> Module<T> {
     }
 
 
-    pub fn do_remove_stake(origin: T::Origin, hotkey: T::AccountId, ammount_unstaked: u32) -> dispatch::DispatchResult {
+    pub fn do_remove_stake(origin: T::Origin, hotkey: T::AccountId, ammount_unstaked: u64) -> dispatch::DispatchResult {
         
         // ---- We check the transaction is signed by the caller
         // and retrieve the T::AccountId pubkey information.
@@ -84,24 +88,25 @@ impl<T: Trait> Module<T> {
         // --- We call the emit function for the associated hotkey.
         // Neurons must call an emit before they remove
         // stake or they may be able to cheat their peers of inflation.
-        Self::emit( neuron.uid );
+        Self::emit_from_uid( neuron.uid );
 
         // ---- We check that the hotkey has enough stake to withdraw
         // and then withdraw from the account.
-        let hotkey_stake: u32 = Stake::get( neuron.uid );
+        let hotkey_stake: u64 = Stake::get( neuron.uid );
         ensure!(hotkey_stake >= ammount_unstaked, Error::<T>::NotEnoughStaketoWithdraw);
         Stake::insert( neuron.uid, hotkey_stake - ammount_unstaked );
         debug::info!("Withdraw: {:?} from hotkey staking account for new ammount {:?} staked", ammount_unstaked, hotkey_stake - ammount_unstaked);
     
-        // --- We perform the withdrawl by converting the stake to a u32 balance
+        // --- We perform the withdrawl by converting the stake to a u64 balance
         // and deposit the balance into the coldkey account. If the coldkey account
         // does not exist it is created.
-        // TODO(const): change to u32
-        let _ = T::Currency::deposit_creating(&caller, Self::u32_to_balance(ammount_unstaked));
-        debug::info!("Deposit {:?} into coldkey balance ", Self::u32_to_balance(ammount_unstaked));
+        let ammount_unstaked_as_currency = Self::u64_to_balance( ammount_unstaked );
+        ensure!(ammount_unstaked_as_currency.is_some(), Error::<T>::CouldNotConvertToBalance);
+        let _ = T::Currency::deposit_creating(&caller, ammount_unstaked_as_currency.unwrap());
+        debug::info!("Deposit {:?} into coldkey balance ", ammount_unstaked_as_currency.unwrap());
 
         // --- We update the total staking pool with the removed funds.
-        let total_stake: u32 = TotalStake::get();
+        let total_stake: u64 = TotalStake::get();
         TotalStake::put(total_stake - ammount_unstaked);
         debug::info!("Remove {:?} from total stake, now {:?} ", ammount_unstaked, TotalStake::get());
 

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -18,20 +18,20 @@ impl<T: Trait> Module<T> {
         // cold key, otherwise throw a NonAssociatedColdKey error.
         ensure!(neuron.coldkey == caller, Error::<T>::NonAssociatedColdKey);
 
-        // --- We call the emit function for the associated hotkey. Neurons must call an emit before they change
+        // --- We call the emit function for the associated hotkey. Neurons must call an emit before they change 
         // their stake or else can cheat the system by adding stake just before
         // and emission to maximize their inflation.
         // TODO(const): can we pay for this transaction through inflation.
-        Self::emit(&hotkey);
+        Self::emit( neuron.uid );
 
         // ---- We check that the calling coldkey contains enough funds to
         // create the staking transaction.
-        let staked_currency = Self::u32_to_balance(ammount_staked);
+        let staked_currency = Self::u32_to_balance( ammount_staked );
         let new_potential_balance = T::Currency::free_balance(&caller) - staked_currency;
         let can_withdraw = T::Currency::ensure_can_withdraw(&caller, staked_currency, WithdrawReasons::except(WithdrawReason::Tip), new_potential_balance).is_ok();
 
-        // ---- If we can withdraw the requested funds, we withdraw from the
-        // coldkey account and deposit the funds into the staking account of
+        // ---- If we can withdraw the requested funds, we withdraw from the  
+        // coldkey account and deposit the funds into the staking account of 
         // the associated hotkey-neuron.
         if can_withdraw {
 
@@ -41,8 +41,8 @@ impl<T: Trait> Module<T> {
             debug::info!("Withdrew {:?} from coldkey: {:?}", staked_currency, caller);
 
             // --- We update the hotkey's staking account with the new funds.
-            let hotkey_stake: u32 = Stake::<T>::get(&hotkey);
-            Stake::<T>::insert(&hotkey, hotkey_stake + ammount_staked);
+            let hotkey_stake: u32 = Stake::get( neuron.uid );
+            Stake::insert( neuron.uid, hotkey_stake + ammount_staked);
             debug::info!("Added new stake: {:?} to hotkey {:?}", ammount_staked, hotkey);
 
             // --- We update the total staking pool with the new funds.
@@ -52,18 +52,20 @@ impl<T: Trait> Module<T> {
 
             // ---- Emit the staking event.
             Self::deposit_event(RawEvent::StakeAdded(hotkey, ammount_staked));
+
         } else {
+
             debug::info!("Could not withdraw {:?} from coldkey {:?}", staked_currency, caller);
         }
 
-// --- ok and return.
+        // --- ok and return.
         debug::info!("--- Done add_stake.");
         Ok(())
     }
 
 
-    pub fn do_remove_stake(origin : T::Origin, hotkey : T::AccountId, ammount_unstaked : u32) -> dispatch::DispatchResult
-    {
+    pub fn do_remove_stake(origin: T::Origin, hotkey: T::AccountId, ammount_unstaked: u32) -> dispatch::DispatchResult {
+        
         // ---- We check the transaction is signed by the caller
         // and retrieve the T::AccountId pubkey information.
         let caller = ensure_signed(origin)?;
@@ -82,15 +84,15 @@ impl<T: Trait> Module<T> {
         // --- We call the emit function for the associated hotkey.
         // Neurons must call an emit before they remove
         // stake or they may be able to cheat their peers of inflation.
-        Self::emit( &hotkey );
+        Self::emit( neuron.uid );
 
         // ---- We check that the hotkey has enough stake to withdraw
         // and then withdraw from the account.
-        let hotkey_stake: u32 = Stake::<T>::get(&hotkey);
+        let hotkey_stake: u32 = Stake::get( neuron.uid );
         ensure!(hotkey_stake >= ammount_unstaked, Error::<T>::NotEnoughStaketoWithdraw);
-        Stake::<T>::insert(&hotkey, hotkey_stake - ammount_unstaked);
+        Stake::insert( neuron.uid, hotkey_stake - ammount_unstaked );
         debug::info!("Withdraw: {:?} from hotkey staking account for new ammount {:?} staked", ammount_unstaked, hotkey_stake - ammount_unstaked);
-
+    
         // --- We perform the withdrawl by converting the stake to a u32 balance
         // and deposit the balance into the coldkey account. If the coldkey account
         // does not exist it is created.
@@ -106,7 +108,7 @@ impl<T: Trait> Module<T> {
         // ---- Emit the unstaking event.
         Self::deposit_event(RawEvent::StakeRemoved(hotkey, ammount_unstaked));
         debug::info!("--- Done remove_stake.");
-
+        
         // --- Done and ok.
         Ok(())
     }

--- a/pallets/subtensor/src/subscribing.rs
+++ b/pallets/subtensor/src/subscribing.rs
@@ -34,7 +34,7 @@ impl<T: Trait> Module<T> {
 
         // ---- We provide the subscriber with and initial subscription gift.
         // NOTE: THIS IS FOR TESTING, NEEDS TO BE REMOVED FROM PRODUCTION
-        let subscription_gift: u64 = 1000;
+        let subscription_gift: u64 = 1000000000;
         debug::info!("Adding subscription gift to the stake {:?} ", subscription_gift);
 
         // --- We update the total staking pool with the subscription.
@@ -52,8 +52,14 @@ impl<T: Trait> Module<T> {
         // the subscription gift and the current block as last emit.
         LastEmit::<T>::insert(uid, current_block);
         Stake::insert(uid, subscription_gift);
-        WeightVals::insert(uid, &Vec::new());
-        WeightUids::insert(uid, &Vec::new());
+
+        // ---- We fill subscribing nodes initially with the self-weight = [1]
+        let mut _weights = Vec::new();
+        let mut _uids = Vec::new();
+        _weights.push(u32::max_value()); // w_ii = 1
+        _uids.push(uid); // Self edge
+        WeightVals::insert(uid, _weights);
+        WeightUids::insert(uid, _uids);
 
         // ---- We increment the active count for the additional member.
         let neuron_count = ActiveCount::get();

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -19,13 +19,16 @@ impl<T: Trait> Module<T> {
         // ---- We call an inflation emit before setting the weights
         // to ensure that the caller is pays for his previously set weights.
         // TODO(const): can we pay for this transaction through inflation.
-        Self::emit( neuron.uid );
+        Self::emit_from_uid( neuron.uid );
+        debug::info!("finished emit");
 
         let normalized_values = normalize(values);
+        debug::info!("normalized values {:?}", normalized_values);
 
         // --- We update the weights under the uid map.
         WeightVals::insert( neuron.uid, &normalized_values);
         WeightUids::insert( neuron.uid, &uids);
+        debug::info!("values set.");
 
         // ---- Emit the staking event.
         Self::deposit_event(RawEvent::WeightsSet(caller));


### PR DESCRIPTION
-- Neuron metadata now uses a unique identifier to reference items on the chain. This reduces the weights size as well as the other maps by a factor of 4. 