### PR TITLE
#177732532 1% of weight transaction fees

### DIFF
--- a/pallets/subtensor/src/emission.rs
+++ b/pallets/subtensor/src/emission.rs
@@ -100,13 +100,13 @@ impl<T: Trait> Module<T> {
             // --- We check if the weight is a self loop. In this case, the emission does not proceed
             // to deposit new funds. The self weight is purely used to pay for transactions fees.
             // The payment of the self weight is done in the post dispatch of the signed extension.
-            if *dest_uid != neuron.uid {
-                Self::add_stake_to_neuron_hotkey_account(*dest_uid, stake_increment);
-            } else {
-                // The self weight is used to pay the transaction fee with. 99% goes back into the neuron
-                // 1% is used for the transaction fee
-                Self::add_stake_to_neuron_hotkey_account(*dest_uid, Self::get_self_emission_minus_transaction_fee(stake_increment));
-            }
+            // if *dest_uid != neuron.uid {
+            Self::add_stake_to_neuron_hotkey_account(*dest_uid, stake_increment);
+            // } else {
+            //     // The self weight is used to pay the transaction fee with. 99% goes back into the neuron
+            //     // 1% is used for the transaction fee
+            //     Self::add_stake_to_neuron_hotkey_account(*dest_uid, Self::get_self_emission_minus_transaction_fee(stake_increment));
+            // }
 
             // --- We increase the total stake emitted.
             total_new_stake += stake_increment;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -625,7 +625,7 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> where
     }
 
     pub fn can_pay_set_weights(who: &T::AccountId) -> Result<TransactionFee, TransactionValidityError> {
-        let transaction_fee = Module::<T>::get_self_emission_for_caller(who);
+        let transaction_fee = Module::<T>::get_transaction_fee_for_emission(who);
         Ok(transaction_fee)
     }
 

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -41,7 +41,6 @@ impl<T: Trait> Module<T> {
         // ---- Emit the staking event.
         Self::deposit_event(RawEvent::StakeAdded(hotkey, stake_to_be_added));
 
-
         // --- ok and return.
         Ok(())
     }

--- a/pallets/subtensor/tests/emission_tests.rs
+++ b/pallets/subtensor/tests/emission_tests.rs
@@ -115,11 +115,11 @@ fn test_self_weight() {
 	new_test_ext().execute_with(|| {
         // Let's subscribe a new neuron to the chain.
         let hotkey:u64 = 1;
-        let stake:u64 = 1000000000;
+        let stake:u64 = 1_000_000_000;
         let neuron = random_neuron_with_stake(hotkey, stake, ipv4(8,8,8,8), 1, 4, 0, 1);
 
         // Let's set this neuron's weights. (0,0) = 1
-        let weight_uids = vec![neuron.uid];
+        let weight_uids = vec![neuron.uid]; // self weight
         let weight_values = vec![u32::MAX]; 
         assert_ok!(SubtensorModule::set_weights(<<Test as Trait>::Origin>::signed(hotkey), weight_uids.clone(), weight_values.clone()));
         assert_eq!(SubtensorModule::get_weights_for_neuron(&neuron), (weight_uids, weight_values)); // Check the weights are set.
@@ -134,20 +134,22 @@ fn test_self_weight() {
   
         // Let's call emit again.
         let total_emission:u64 = SubtensorModule::emit_for_neuron(&neuron);
-        assert_eq!(total_emission, 500000000);
+        assert_eq!(total_emission, 500_000_000);
 
-        // Verify that the self emission does not got to the neuron itself
-        assert_eq!(1_000_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
+        // Verify that 99% of the self emissison goes to the neuron
+        // 1_000_000_000 + 500_000_000 * 0.99 = 1_495_000_000
+        assert_eq!(1_495_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
 
         // Increase the block number by 1
         run_to_block(2);
 
         // Let's call emit again.
         let total_emission:u64 = SubtensorModule::emit_for_neuron(&neuron);
-        assert_eq!(total_emission, 500000000);
+        assert_eq!(total_emission, 500_000_000);
 
-        // Verify that the self emission does not got to the neuron itself
-        assert_eq!(1_000_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
+        // Verify that 99% of the self emissison goes to the neuron
+        // 1_490_000_000 + 500_000_000 * 0.99 = 1_990_000_000
+        assert_eq!(1_990_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
 
 	});
 }

--- a/pallets/subtensor/tests/emission_tests.rs
+++ b/pallets/subtensor/tests/emission_tests.rs
@@ -136,9 +136,8 @@ fn test_self_weight() {
         let total_emission:u64 = SubtensorModule::emit_for_neuron(&neuron);
         assert_eq!(total_emission, 500_000_000);
 
-        // Verify that 99% of the self emissison goes to the neuron
-        // 1_000_000_000 + 500_000_000 * 0.99 = 1_495_000_000
-        assert_eq!(1_495_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
+        // Verify that 100% of the self emissison goes to the neuron
+        assert_eq!(1_500_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
 
         // Increase the block number by 1
         run_to_block(2);
@@ -149,7 +148,7 @@ fn test_self_weight() {
 
         // Verify that 99% of the self emissison goes to the neuron
         // 1_490_000_000 + 500_000_000 * 0.99 = 1_990_000_000
-        assert_eq!(1_990_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
+        assert_eq!(2_000_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that the stake is there.
 
 	});
 }

--- a/pallets/subtensor/tests/lib.rs
+++ b/pallets/subtensor/tests/lib.rs
@@ -90,19 +90,16 @@ fn fee_from_emission_priority_with_neuron_and_weights_and_stake_and_run_to_block
         let weight_uids = vec![neuron.uid];
         let weight_values = vec![u32::MAX];
         assert_ok!(SubtensorModule::set_weights(Origin::signed(hotkey_account_id), weight_uids.clone(), weight_values.clone()));
-        SubtensorModule::add_stake_to_neuron_hotkey_account(neuron.uid, 1000000000); // Add the stake.
+        SubtensorModule::add_stake_to_neuron_hotkey_account(neuron.uid, 1_000_000_000); // Add the stake.
 
         let call = SubtensorCall::set_weights(vec![0], vec![0]).into();
         let info = DispatchInfo::default();
         let len = 10;
         assert_eq!(ChargeTransactionPayment::<Test>(PhantomData).validate(&hotkey_account_id, &call, &info, len).unwrap().priority, 0);
         run_to_block(1);
-        assert_eq!(ChargeTransactionPayment::<Test>(PhantomData).validate(&hotkey_account_id, &call, &info, len).unwrap().priority, 50000000);
-        assert_eq!(1000000000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has not increased.
+        assert_eq!(ChargeTransactionPayment::<Test>(PhantomData).validate(&hotkey_account_id, &call, &info, len).unwrap().priority, 500_000);
+        assert_eq!(1_000_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has increased with 99% of the BR
         let _total_emission: u64 = SubtensorModule::emit_for_neuron(&neuron); // actually do the emission.
-
-        // This step now takes places in the post dispatch
-        // assert_eq!( 1500000000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has increased (he is adam)
     });
 }
 
@@ -144,21 +141,18 @@ fn fee_from_emission_priority_with_neuron_and_adam() {
         let weight_uids = vec![neuron.uid];
         let weight_values = vec![u32::MAX];
         assert_ok!(SubtensorModule::set_weights(Origin::signed(hotkey_account_id), weight_uids.clone(), weight_values.clone()));
-        SubtensorModule::add_stake_to_neuron_hotkey_account(neuron.uid, 1000000000); // Add the stake.
+        SubtensorModule::add_stake_to_neuron_hotkey_account(neuron.uid, 1_000_000_000); // Add the stake.
 
         let call = SubtensorCall::set_weights(vec![0], vec![0]).into();
         let info = DispatchInfo::default();
         let len = 10;
         assert_eq!(ChargeTransactionPayment::<Test>(PhantomData).validate(&hotkey_account_id, &call, &info, len).unwrap().priority, 0);
         run_to_block(1);
-        assert_eq!(ChargeTransactionPayment::<Test>(PhantomData).validate(&hotkey_account_id, &call, &info, len).unwrap().priority, 50000000);
-        assert_eq!(1000000000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has not increased.
+        assert_eq!(ChargeTransactionPayment::<Test>(PhantomData).validate(&hotkey_account_id, &call, &info, len).unwrap().priority, 500_000);
+        assert_eq!(1_000_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has not increased.
 
         let _total_emission: u64 = SubtensorModule::emit_for_neuron(&neuron); // actually do the emission.
-        assert_eq!(1000000000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has increased (he is *not* adam)
-        // assert_eq!( 500000000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(adam.uid)); // Check that his stake has increased (he is adam)
-
-        // This takes place in post-dispatch. Make necessary adaptations
+        assert_eq!(1_495_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has increased (he is *not* adam)
     });
 }
 
@@ -175,7 +169,7 @@ fn test_charge_transaction_payment_can_pay_set_weights_ok() {
         let _adam = subscribe_ok_neuron(0, 787687); // Now has self-weight
 
         let result = ChargeTransactionPayment::<Test>::can_pay_set_weights(&hotkey_id);
-        assert_eq!(result, Ok(1000));
+        assert_eq!(result, Ok(10));
     });
 }
 
@@ -359,7 +353,7 @@ fn test_charge_transaction_payment_validate_set_weights_ok() {
 
         let result = ChargeTransactionPayment::<Test>(PhantomData).validate(&coldkey_id, &call, &info, len);
         assert_eq!(result, Ok(ValidTransaction {
-            priority: 500,
+            priority: 5,
             longevity: 1,
             ..Default::default()
         }))
@@ -467,7 +461,7 @@ fn pre_dispatch_works() {
 
         result = ChargeTransactionPayment::<Test>(PhantomData).pre_dispatch(&hotkey_account_id, &call, &info, len).unwrap();
         assert_eq!(result.0, CallType::SetWeights);
-        assert_eq!(result.1, 500000000);
+        assert_eq!(result.1, 5_000_000);
         assert_eq!(result.2, hotkey_account_id);
     });
 }
@@ -535,7 +529,7 @@ fn post_dispatch_deposit_to_transaction_fee_pool_works() {
         run_to_block(1);
         let pre = ChargeTransactionPayment::<Test>(PhantomData).pre_dispatch(&hotkey_account_id, &call, &info, len).unwrap();
         assert!(ChargeTransactionPayment::<Test>::post_dispatch(pre, &info, &PostDispatchInfo { actual_weight: Some(0), pays_fee: Default::default() }, len, &Ok(())).is_ok());
-        assert_eq!(SubtensorModule::get_transaction_fee_pool(), 500_000_000);
+        assert_eq!(SubtensorModule::get_transaction_fee_pool(), 5_000_000); // 1%
     });
 }
 

--- a/pallets/subtensor/tests/lib.rs
+++ b/pallets/subtensor/tests/lib.rs
@@ -152,7 +152,7 @@ fn fee_from_emission_priority_with_neuron_and_adam() {
         assert_eq!(1_000_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has not increased.
 
         let _total_emission: u64 = SubtensorModule::emit_for_neuron(&neuron); // actually do the emission.
-        assert_eq!(1_495_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has increased (he is *not* adam)
+        assert_eq!(1_500_000_000, SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron.uid)); // Check that his stake has increased (he is *not* adam)
     });
 }
 

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -228,7 +228,7 @@ fn test_remove_stake_dispatch_info_ok() {
 }
 
 #[test]
-fn test_remove_stake_ok_transaction_fee_ends_up_in_adam_account() {
+fn test_remove_stake_ok_transaction_fee_ends_up_in_transaction_fee_pool() {
 	let coldkey_id = 667;
 	let initial_stake : u64 = 1_000_000_000;
 	let hotkey_id = 1;
@@ -333,36 +333,7 @@ fn test_remove_stake_err_signature() {
 	});
 }
 
-/*
-#[test]
-fn test_add_stake_err_not_active() {
-	new_test_ext().execute_with(|| {
-		let coldkey_account_id = 435445; // Not active id
-		let hotkey_account_id = 54544;
-		let amount = 1337;
 
-		let result = SubtensorModule::add_stake(<<Test as Trait>::Origin>::signed(coldkey_account_id), hotkey_account_id, amount);
-		assert_eq!(result, Err(Error::<Test>::NotActive.into()));
-	});
-}
-
-
-#[test]
-fn test_add_stake_err_neuron_does_not_belong_to_coldkey() {
-	new_test_ext().execute_with(|| {
-		let coldkey_id = 544;
-		let hotkey_id = 54544;
-		let other_cold_key = 99498;
-
-		let _neuron = subscribe_neuron(hotkey_id, ipv4(8, 8, 8, 8), 66, 4, 0, coldkey_id);
-
-		// Perform the request which is signed by a different cold key
-		let result = SubtensorModule::add_stake(<<Test as Trait>::Origin>::signed(other_cold_key), hotkey_id, 1000);
-		assert_eq!(result, Err(Error::<Test>::NonAssociatedColdKey.into()));
-	});
-}
-
- */
 #[test]
 fn test_remove_stake_err_not_active() {
 	new_test_ext().execute_with(|| {

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -5,6 +5,7 @@ use pallet_subtensor::{Call as SubtensorCall, Error};
 use frame_support::weights::{GetDispatchInfo, DispatchInfo, DispatchClass, Pays};
 use frame_support::{assert_ok};
 use sp_runtime::DispatchError;
+use fixed::types::U64F64;
 
 
 /***************************
@@ -30,13 +31,23 @@ fn test_set_weights_dispatch_info_ok() {
 
 
 #[test]
-fn test_set_weights_transaction_fee_pool_receives_funds() {
+fn test_set_weights_transaction_fee_pool_and_neuron_receive_funds() {
 	new_test_ext().execute_with(|| {
 		let w_uids = vec![1, 2]; // When applied to neuron_1, this will set 50% to himself and 50% to neuron_2
-		let w_vals = vec![50, 50];
+		let w_vals = vec![50, 50]; // The actual numbers are irrelevant for this test though
 
 		let neuron_1_id = 1;
 		let neuron_2_id = 2;
+
+		let block_reward = U64F64::from_num(500_000_000);
+		let neuron_1_stake = 1_000_000_000;  // This is the stake that will be given to neuron 1
+		let expected_transaction_fee_pool = (block_reward as U64F64 * U64F64::from_num(0.01)).round().to_num::<u64>(); // This is the stake to be expected after applying set_weights
+		let expected_neuron_1_stake = neuron_1_stake + (block_reward * U64F64::from_num(0.99)).round().to_num::<u64>();
+
+
+		// let bleh = U64F64::from_num(500_000_000) * U64F64::from_num(0.99);
+		// assert_eq!(4444,bleh);
+
 
 		let _adam    = subscribe_ok_neuron(0, 666);
 		let _neuron1 = subscribe_ok_neuron(neuron_1_id, 666); // uid 1
@@ -44,7 +55,8 @@ fn test_set_weights_transaction_fee_pool_receives_funds() {
 
 		// Add 1 Tao to neuron 1. He now hold 100% of the stake, so will get the full emission,
 		// also he only has a self_weight.
-		SubtensorModule::add_stake_to_neuron_hotkey_account(_neuron1.uid, 1_000_000_000);
+
+		SubtensorModule::add_stake_to_neuron_hotkey_account(_neuron1.uid, neuron_1_stake);
 
 		// Move to block, to build up pending emission
 		mock::run_to_block(1); // This will emit .5 TAO to neuron 1, since he has 100% of the total stake
@@ -58,7 +70,7 @@ fn test_set_weights_transaction_fee_pool_receives_funds() {
 		let xt = TestXt::new(call, mock::sign_extra(_neuron1.uid,0)); // Apply t
 
 		// Execute. This will trigger the set_weights function to emit, before the new weights are set.
-		// Resulting in Adam getting his full emission.
+		// Resulting in neuron1 getting 99% of the block reward and 1% going to the transaction pool
 		let result = mock::Executive::apply_extrinsic(xt);
 
 		// Verfify success
@@ -67,12 +79,10 @@ fn test_set_weights_transaction_fee_pool_receives_funds() {
 		let transaction_fees_pool = SubtensorModule::get_transaction_fee_pool();
 		let neuron_1_new_stake = SubtensorModule::get_stake_of_neuron_hotkey_account_by_uid(neuron_1_id);
 
-		assert_eq!(transaction_fees_pool, 500_000_000);
-		assert_eq!(neuron_1_new_stake, 1_000_000_000);  // Neuron 1 maintains its stake
+		assert_eq!(transaction_fees_pool, expected_transaction_fee_pool);
+		assert_eq!(neuron_1_new_stake, expected_neuron_1_stake);  // Neuron 1 maintains his original stake + 99% of the block reward
 	});
 }
-
-
 
 
 


### PR DESCRIPTION
Solved a problem with how the set_weights function is paid for. The original implementation determines the transaction fee based on the pending self-emission, which is 1%. Then, the extrinsic is dispatched, and 99% then goes into its staking account. When the transaction is finished, the transaction fee goes into the transaction fee pool.

This caused a problem with the add_stake and remove_stake functions, as they call the emit function as well as the set_weights function. This caused a node to pay the regular fee for both functions as well as 1% deduction of his self-emission. This would lead to annihilation of tokens.

The problem has been fixed by removing the "99% goes into own account" logic altogether. Instead, the full self-emission occurs, and the 1% transaction fee is deducted from the neuron's stake.

Previously, this solution was already in mind, but due to some confusion in the post_dispatch code, this was deemed not possible.

